### PR TITLE
Fix the project name in the README (in the mention of the license)

### DIFF
--- a/CTAppearance/CTAppearance.h
+++ b/CTAppearance/CTAppearance.h
@@ -1,5 +1,5 @@
 //
-//  CTApperance.h
+//  CTAppearance.h
 //  AppearanceTest
 //
 //  Created by David Fumberger on 11/09/2013.

--- a/CTAppearance/CTAppearance.m
+++ b/CTAppearance/CTAppearance.m
@@ -1,5 +1,5 @@
 //
-//  CTApperance.m
+//  CTAppearance.m
 //  AppearanceTest
 //
 //  Created by David Fumberger on 11/09/2013.

--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ The solutions I know about to fix / support this feature require a lot of swizzl
 [@djfumberger](https://twitter.com/djfumberger)
 
 ## License
-CTChromecast is available under the MIT license. See the LICENSE file for more info.
+CTAppearance is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
Fix the project name in the README (in the mention of the license -- I hope the change is accurate ;-) ), and the class name in file comments.

I'll have another pull request shortly with some functionality fixes.
